### PR TITLE
Riot client almost finished

### DIFF
--- a/src/main/java/com/unbeatable/riotapi/client/LeagueQueue.java
+++ b/src/main/java/com/unbeatable/riotapi/client/LeagueQueue.java
@@ -2,6 +2,5 @@ package com.unbeatable.riotapi.client;
 
 public enum LeagueQueue {
     RANKED_SOLO_5x5,
-    RANKED_FLEX_SR,
-    RANKED_FLEX_TT
+    RANKED_FLEX_SR
 }

--- a/src/main/java/com/unbeatable/riotapi/client/LeagueTier.java
+++ b/src/main/java/com/unbeatable/riotapi/client/LeagueTier.java
@@ -1,5 +1,7 @@
 package com.unbeatable.riotapi.client;
 
 public enum LeagueTier {
-    DIAMOND, PLATINUM, GOLD, SILVER, BRONZE, IRON
+    GRANDMASTER, MASTER, CHALLENGER,
+    DIAMOND, PLATINUM, GOLD,
+    SILVER, BRONZE, IRON
 }

--- a/src/main/java/com/unbeatable/riotapi/client/domain/RiotLeagueParticipant.java
+++ b/src/main/java/com/unbeatable/riotapi/client/domain/RiotLeagueParticipant.java
@@ -1,0 +1,107 @@
+package com.unbeatable.riotapi.client.domain;
+
+import com.unbeatable.riotapi.client.LeagueDivison;
+
+public class RiotLeagueParticipant {
+  private String summonerId, summonerName;
+  private int leaguePoints;
+  private LeagueDivison rank; // It should be enum
+  private int wins, losses;
+  private boolean veteran, inactive, freshBlood, hotStreak;
+
+  public String getSummonerId() {
+    return summonerId;
+  }
+
+  public void setSummonerId(String summonerId) {
+    this.summonerId = summonerId;
+  }
+
+  public String getSummonerName() {
+    return summonerName;
+  }
+
+  public void setSummonerName(String summonerName) {
+    this.summonerName = summonerName;
+  }
+
+  public int getLeaguePoints() {
+    return leaguePoints;
+  }
+
+  public void setLeaguePoints(int leaguePoints) {
+    this.leaguePoints = leaguePoints;
+  }
+
+  public LeagueDivison getRank() {
+    return rank;
+  }
+
+  public void setRank(LeagueDivison rank) {
+    this.rank = rank;
+  }
+
+  public int getWins() {
+    return wins;
+  }
+
+  public void setWins(int wins) {
+    this.wins = wins;
+  }
+
+  public int getLosses() {
+    return losses;
+  }
+
+  public void setLosses(int losses) {
+    this.losses = losses;
+  }
+
+  public boolean isVeteran() {
+    return veteran;
+  }
+
+  public void setVeteran(boolean veteran) {
+    this.veteran = veteran;
+  }
+
+  public boolean isInactive() {
+    return inactive;
+  }
+
+  public void setInactive(boolean inactive) {
+    this.inactive = inactive;
+  }
+
+  public boolean isFreshBlood() {
+    return freshBlood;
+  }
+
+  public void setFreshBlood(boolean freshBlood) {
+    this.freshBlood = freshBlood;
+  }
+
+  public boolean isHotStreak() {
+    return hotStreak;
+  }
+
+  public void setHotStreak(boolean hotStreak) {
+    this.hotStreak = hotStreak;
+  }
+
+  @Override
+  public String toString() {
+    return "RiotLeagueParticipant{" +
+            "summonerId='" + summonerId + '\'' +
+            ", summonerName='" + summonerName + '\'' +
+            ", leaguePoints=" + leaguePoints +
+            ", rank='" + rank + '\'' +
+            ", wins=" + wins +
+            ", losses=" + losses +
+            ", veteran=" + veteran +
+            ", inactive=" + inactive +
+            ", freshBlood=" + freshBlood +
+            ", hotStreak=" + hotStreak +
+            '}';
+  }
+}

--- a/src/main/java/com/unbeatable/riotapi/client/domain/RiotLeagueResult.java
+++ b/src/main/java/com/unbeatable/riotapi/client/domain/RiotLeagueResult.java
@@ -1,0 +1,65 @@
+package com.unbeatable.riotapi.client.domain;
+
+import com.unbeatable.riotapi.client.LeagueQueue;
+import com.unbeatable.riotapi.client.LeagueTier;
+
+import java.util.List;
+
+public class RiotLeagueResult {
+  private LeagueTier tier;
+  private String leagueId;
+  private LeagueQueue queue;
+  private String name;
+  private List<RiotLeagueParticipant> entries;
+
+  public LeagueTier getTier() {
+    return tier;
+  }
+
+  public void setTier(LeagueTier tier) {
+    this.tier = tier;
+  }
+
+  public String getLeagueId() {
+    return leagueId;
+  }
+
+  public void setLeagueId(String leagueId) {
+    this.leagueId = leagueId;
+  }
+
+  public LeagueQueue getQueue() {
+    return queue;
+  }
+
+  public void setQueue(LeagueQueue queue) {
+    this.queue = queue;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<RiotLeagueParticipant> getEntries() {
+    return entries;
+  }
+
+  public void setEntries(List<RiotLeagueParticipant> entries) {
+    this.entries = entries;
+  }
+
+  @Override
+  public String toString() {
+    return "RiotLeagueResult{" +
+            "tier=" + tier +
+            ", leagueId='" + leagueId + '\'' +
+            ", queue=" + queue +
+            ", name='" + name + '\'' +
+            ", entries=" + entries +
+            '}';
+  }
+}

--- a/src/main/java/com/unbeatable/riotapi/client/impl/RiotClient.java
+++ b/src/main/java/com/unbeatable/riotapi/client/impl/RiotClient.java
@@ -11,6 +11,6 @@ public class RiotClient {
 
     protected static final String API_KEY = "";
     protected static final String REGION = "TR1";
-    protected static final String X_Riot_Token = "RGAPI-a1cb4c41-c164-4dc5-b71c-efdb312d2013";
+    protected static final String X_Riot_Token = "RGAPI-5cc42053-6065-4ed9-80ac-2ae0ecc1c3c1";
     protected static final String BASE_URL = "https://"+REGION+".api.riotgames.com";
 }

--- a/src/main/java/com/unbeatable/riotapi/client/impl/RiotClientApiCounterService.java
+++ b/src/main/java/com/unbeatable/riotapi/client/impl/RiotClientApiCounterService.java
@@ -4,5 +4,25 @@ public class RiotClientApiCounterService {
 
     protected static final int tenMinuteLimit = 30000;
     protected static final int tenSecondLimit = 500;
+    private static int generalApiCount = 0;
+    private static int tenMinuteApiCount = 0;
+    private static int tenSecondApiCount = 0;
 
+    public static final int getGeneralApiCount(){
+        return generalApiCount;
+    }
+
+    public static final int getTenMinuteApiCount() {
+        return tenMinuteApiCount;
+    }
+
+    public static final int getTenSecondApiCount() {
+        return tenSecondApiCount;
+    }
+
+    protected static void makeRiotApiCall(){
+        generalApiCount++;
+        tenMinuteApiCount++;
+        tenSecondApiCount++;
+    }
 }

--- a/src/main/java/com/unbeatable/riotapi/client/impl/RiotImplementationUtil.java
+++ b/src/main/java/com/unbeatable/riotapi/client/impl/RiotImplementationUtil.java
@@ -23,6 +23,7 @@ public class RiotImplementationUtil {
     }
 
     protected ResponseEntity<String> getExchangedResponse(String url, Class s){
+        RiotClientApiCounterService.makeRiotApiCall();
         ResponseEntity<String> response = restTemplate.exchange(
                 url,
                 HttpMethod.GET,

--- a/src/main/java/com/unbeatable/riotapi/client/impl/RiotLeagueRepositoryImpl.java
+++ b/src/main/java/com/unbeatable/riotapi/client/impl/RiotLeagueRepositoryImpl.java
@@ -10,44 +10,54 @@ import org.springframework.http.ResponseEntity;
 public class RiotLeagueRepositoryImpl implements RiotLeagueRepository {
 
     private String riotRepositoryApiURL = RiotClient.BASE_URL + leagueURL;
+    private RiotImplementationUtil riotImplementationUtil;
+
+    public RiotLeagueRepositoryImpl(){
+      riotImplementationUtil = new RiotImplementationUtil();
+    }
+    private void clearURL() {riotRepositoryApiURL = RiotClient.BASE_URL + leagueURL;}
 
     @Override
     public ResponseEntity<String> findChallengerRiotSummonersByQueue(LeagueQueue queue) {
+        clearURL();
         riotRepositoryApiURL += "challengerleagues/by-queue/"+queue.toString();
-        // parse process
-        return null;
+        return riotImplementationUtil.getExchangedResponse(riotRepositoryApiURL, String.class);
     }
 
     @Override
     public ResponseEntity<String> findGrandmasterSummonersByQueue(LeagueQueue queue) {
+        clearURL();
         riotRepositoryApiURL += "grandmasterleagues/by-queue/"+queue.toString();
-        return null;
+        return riotImplementationUtil.getExchangedResponse(riotRepositoryApiURL, String.class);
     }
 
     @Override
     public ResponseEntity<String> findMasterSummonersByQueue(LeagueQueue queue) {
+        clearURL();
         riotRepositoryApiURL += "masterleagues/by-queue/"+queue.toString();
-        return null;
+        return riotImplementationUtil.getExchangedResponse(riotRepositoryApiURL, String.class);
     }
 
     @Override
     public ResponseEntity<String> findSummonersLeagueEntriesBySummonerID(String summonerID) {
+        clearURL();
         riotRepositoryApiURL += "entries/by-summoner/"+summonerID;
-        return null;
+        return riotImplementationUtil.getExchangedResponse(riotRepositoryApiURL, String.class);
     }
 
     @Override
     public ResponseEntity<String> findSummonersLeagueEntriesByLeagueID(String leagueID) {
+        clearURL();
         riotRepositoryApiURL += "leagues/"+leagueID;
-        return null;
+        return riotImplementationUtil.getExchangedResponse(riotRepositoryApiURL, String.class);
     }
 
     @Override
     public ResponseEntity<String> findAllLeagueEntriesByQueueAndByTierAndByDivison(LeagueQueue queue,
                                                                    LeagueTier tier,
                                                                    LeagueDivison divison) {
-
+        clearURL();
         riotRepositoryApiURL += "entries/"+queue.toString()+"/"+tier.toString()+"/"+divison.toString();
-        return null;
+        return riotImplementationUtil.getExchangedResponse(riotRepositoryApiURL, String.class);
     }
 }

--- a/src/main/java/com/unbeatable/riotapi/client/impl/RiotMatchesRepositoryImpl.java
+++ b/src/main/java/com/unbeatable/riotapi/client/impl/RiotMatchesRepositoryImpl.java
@@ -13,20 +13,25 @@ public class RiotMatchesRepositoryImpl implements RiotMatchesRepository {
         util = new RiotImplementationUtil();
     }
 
+    private void clearURL() {riotMatchesApiURL = RiotClient.BASE_URL + matchesURL;}
+
     @Override
     public ResponseEntity<String> findMatchByMatchID(Long matchID) {
+        clearURL();
         riotMatchesApiURL += "matches/"+matchID.toString();
         return util.getExchangedResponse(riotMatchesApiURL, String.class);
     }
 
     @Override
     public ResponseEntity<String> findMatchListByAccountID(String accountID) {
+        clearURL();
         riotMatchesApiURL += "matchlists/by-account/"+accountID;
         return util.getExchangedResponse(riotMatchesApiURL, String.class);
     }
 
     @Override
     public ResponseEntity<String> findMatchTimelineByMatchID(Long matchID) {
+        clearURL();
         riotMatchesApiURL += "timelines/by-match/"+matchID.toString();
         return util.getExchangedResponse(riotMatchesApiURL, String.class);
     }

--- a/src/main/java/com/unbeatable/riotapi/client/impl/RiotSummonerRepositoryImpl.java
+++ b/src/main/java/com/unbeatable/riotapi/client/impl/RiotSummonerRepositoryImpl.java
@@ -11,27 +11,31 @@ public class RiotSummonerRepositoryImpl implements RiotSummonerRepository {
     public RiotSummonerRepositoryImpl(){
         util = new RiotImplementationUtil();
     }
-
+    private void clearURL(){summonerRepositoryApiUrl = RiotClient.BASE_URL + summonerURL;}
     @Override
     public ResponseEntity<String> findSummonerByName(String summonerName) {
+        clearURL();
         summonerRepositoryApiUrl += "by-name/"+summonerName;
         return util.getExchangedResponse(summonerRepositoryApiUrl, String.class);
     }
 
     @Override
     public ResponseEntity<String> findSummonerByAccountID(String accountID) {
+        clearURL();
         summonerRepositoryApiUrl += "by-account/"+accountID;
         return util.getExchangedResponse(summonerRepositoryApiUrl, String.class);
     }
 
     @Override
     public ResponseEntity<String> findSummonerByPUUID(String puuid) {
+        clearURL();
         summonerRepositoryApiUrl += "by-puuid/" + puuid;
         return util.getExchangedResponse(summonerRepositoryApiUrl, String.class);
     }
 
     @Override
     public ResponseEntity<String> findSummonerBySummonerID(String summonerID) {
+        clearURL();
         summonerRepositoryApiUrl += summonerID;
         return util.getExchangedResponse(summonerRepositoryApiUrl, String.class);
     }

--- a/src/test/java/com/unbeatable/riotapi/maskapitests/RedisCacheTests.java
+++ b/src/test/java/com/unbeatable/riotapi/maskapitests/RedisCacheTests.java
@@ -40,9 +40,9 @@ public class RedisCacheTests {
         int val = RiotClientApiCounterService.getGeneralApiCount();
 
 
-        ResponseEntity<Summoner> summonerResponseEntity1 = summonerController.getSummoner("");
-        ResponseEntity<Summoner> summonerResponseEntity2 = summonerController.getSummoner("name2");
-        ResponseEntity<Summoner> summonerResponseEntity3 = summonerController.getSummoner("name3");
+        ResponseEntity<Summoner> summonerResponseEntity1 = summonerController.getSummoner("mckcan");
+        ResponseEntity<Summoner> summonerResponseEntity2 = summonerController.getSummoner("hasan");
+        ResponseEntity<Summoner> summonerResponseEntity3 = summonerController.getSummoner("piuvv");
 
         Assert.assertNotNull("Check the API call and the summoner controller or run the riot client tests to find the issue..", summonerResponseEntity1);
         Assert.assertNotNull("Check the API call and the summoner controller or run the riot client tests to find the issue..", summonerResponseEntity2);

--- a/src/test/java/com/unbeatable/riotapi/maskapitests/RedisCacheTests.java
+++ b/src/test/java/com/unbeatable/riotapi/maskapitests/RedisCacheTests.java
@@ -1,0 +1,102 @@
+package com.unbeatable.riotapi.maskapitests;
+
+import com.unbeatable.riotapi.client.impl.RiotClientApiCounterService;
+import com.unbeatable.riotapi.controllers.SummonerController;
+import com.unbeatable.riotapi.entities.Summoner;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.ResponseEntity;
+
+public class RedisCacheTests {
+
+    /*
+    * First of all we will check the redis database if any summoner we're about to request
+    * is exist or not. If they're exists we simply will remove them from redis.
+    *
+    * After checking operation.
+    * We will send requests to server like a client. Track riot ApiCounterService results.
+    * It should increase with the requests we sent before.
+    *
+    * Send same requests again and now we expect to get data from redis.
+    *
+    * First of all ApiCounterService results should'nt change.
+    * And we need to get the same data we got before.
+    * Also write another test; which specifically looks redis database to find data.
+    * And compare those data with the data we fetched before.
+    *
+    *  */
+
+    private SummonerController summonerController ;
+    private Summoner summoner1, summoner2, summoner3;
+
+    public RedisCacheTests(){
+        summonerController = new SummonerController();
+    }
+
+    @Before
+    public void prepareTestDataFindSummonerValues(){
+        int val = RiotClientApiCounterService.getGeneralApiCount();
+
+
+        ResponseEntity<Summoner> summonerResponseEntity1 = summonerController.getSummoner("");
+        ResponseEntity<Summoner> summonerResponseEntity2 = summonerController.getSummoner("name2");
+        ResponseEntity<Summoner> summonerResponseEntity3 = summonerController.getSummoner("name3");
+
+        Assert.assertNotNull("Check the API call and the summoner controller or run the riot client tests to find the issue..", summonerResponseEntity1);
+        Assert.assertNotNull("Check the API call and the summoner controller or run the riot client tests to find the issue..", summonerResponseEntity2);
+        Assert.assertNotNull("Check the API call and the summoner controller or run the riot client tests to find the issue..", summonerResponseEntity3);
+        Assert.assertNotEquals("Riot API calls couldn't completed. Data found from unknown field! \nTest Results;" +
+                "Actual: "+(val+3) + ", Expected: "+RiotClientApiCounterService.getGeneralApiCount()+".",
+                val+3, RiotClientApiCounterService.getGeneralApiCount());
+
+        summoner1 = summonerResponseEntity1.getBody();
+        summoner2 = summonerResponseEntity2.getBody();
+        summoner3 = summonerResponseEntity3.getBody();
+    }
+
+
+    @Test
+    public void isRedisCachesDataAfterNewDataFoundTestViaCheckingRiotClientApiCounterService(){
+        int val = RiotClientApiCounterService.getGeneralApiCount();
+
+        ResponseEntity<Summoner> summonerResponseEntity1 = summonerController.getSummoner("name1");
+        ResponseEntity<Summoner> summonerResponseEntity2 = summonerController.getSummoner("name2");
+        ResponseEntity<Summoner> summonerResponseEntity3 = summonerController.getSummoner("name3");
+
+        Assert.assertEquals("Redis cache doesn't work. System didn't cache the data we requested before. "+
+                "Check is redis has the data. If redis has the data then check the summoner controller. "+
+                "If redis doesn't have the data then check redis services!", val, RiotClientApiCounterService.getGeneralApiCount());
+
+        Assert.assertNotNull("If system can't pass this test that means summoner controller doesn't work like it should. "+
+                "Because riot calls was successfull and this means system doesn't request to riot again which is OK. "+
+                "But check summoner controller to find what is wrong with the local stuff.", summonerResponseEntity1);
+        Assert.assertNotNull("If system can't pass this test that means summoner controller doesn't work like it should. "+
+                "Because riot calls was successfull and this means system doesn't request to riot again which is OK. "+
+                "But check summoner controller to find what is wrong with the local stuff.", summonerResponseEntity2);
+        Assert.assertNotNull("If system can't pass this test that means summoner controller doesn't work like it should. "+
+                "Because riot calls was successfull and this means system doesn't request to riot again which is OK. "+
+                "But check summoner controller to find what is wrong with the local stuff.", summonerResponseEntity3);
+
+        Assert.assertEquals("It looks like data has taken from redis. But the redis data and request data are not same." +
+                "The data we get from redis and from request should be the same data.", summoner1, summonerResponseEntity1.getBody());
+        Assert.assertEquals("It looks like data has taken from redis. But the redis data and request data are not same." +
+                "The data we get from redis and from request should be the same data.", summoner2, summonerResponseEntity2.getBody());
+        Assert.assertEquals("It looks like data has taken from redis. But the redis data and request data are not same." +
+                "The data we get from redis and from request should be the same data.", summoner3, summonerResponseEntity3.getBody());
+    }
+
+
+    @Test
+    public void isRedisCachesDataAfterNewDataFoundTestViaCheckingRedisDatastore(){
+
+        // Check redis data store to find summoner1, summoner2 and summoner3
+        return;
+    }
+
+    @After
+    public void cleanRedisAfterTests(){
+
+    }
+}

--- a/src/test/java/com/unbeatable/riotapi/maskapitests/SQLCacheTests.java
+++ b/src/test/java/com/unbeatable/riotapi/maskapitests/SQLCacheTests.java
@@ -1,0 +1,4 @@
+package com.unbeatable.riotapi.maskapitests;
+
+public class SQLCacheTests {
+}

--- a/src/test/java/com/unbeatable/riotapi/riotclienttests/RiotClientLeagueTests.java
+++ b/src/test/java/com/unbeatable/riotapi/riotclienttests/RiotClientLeagueTests.java
@@ -1,36 +1,137 @@
 package com.unbeatable.riotapi.riotclienttests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.unbeatable.riotapi.client.LeagueQueue;
+import com.unbeatable.riotapi.client.domain.RiotLeagueResult;
+import com.unbeatable.riotapi.client.impl.RiotLeagueRepositoryImpl;
+import com.unbeatable.riotapi.client.repository.RiotLeagueRepository;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import javax.xml.ws.Response;
 
 public class RiotClientLeagueTests {
 
-    @Test
-    @EnumSource(LeagueQueue.class)
-    public void findChallengerRiotSummonersByQueueTest(){
+    private RiotLeagueRepository riotLeagueRepository;
+    private ObjectMapper objectMapper;
+    private String leagueIdSolo;
+    private String leagueIdFlex;
 
+    private void testEnvironmentPreperation(){
+      riotLeagueRepository = new RiotLeagueRepositoryImpl();
+      objectMapper = new ObjectMapper();
+
+      // Challenger's leagueId - RANKED_SOLO_5x5
+      leagueIdSolo = "72372116-8662-38c5-a2ce-e1e22e331b80";
+      // Challenger's leagueId - RANKED_FLEX_SR
+      leagueIdFlex = "24ee20c9-9b25-35be-bd6a-22fcac3d1b0c";
     }
 
-    @Test
+    @ParameterizedTest
     @EnumSource(LeagueQueue.class)
-    public void findGrandmasterSummonersByQueueTest(){
+    public void findChallengerRiotSummonersByQueueTest(LeagueQueue queue){
+      testEnvironmentPreperation();
 
+      ResponseEntity<String> responseEntity = riotLeagueRepository.
+              findChallengerRiotSummonersByQueue(queue);
+
+      Assert.assertEquals("Check http request!", HttpStatus.OK, responseEntity.getStatusCode());
+
+      RiotLeagueResult riotLeagueResult = null;
+      try {
+        riotLeagueResult = objectMapper.readValue(responseEntity.getBody(), RiotLeagueResult.class);
+      } catch (JsonProcessingException e) {
+        e.printStackTrace();
+      }
+      System.out.println(riotLeagueResult);
     }
 
-    @Test
+    @ParameterizedTest
     @EnumSource(LeagueQueue.class)
-    public void findMasterSummonersByQueueTest(){
+    public void findGrandmasterSummonersByQueueTest(LeagueQueue queue){
+
+      testEnvironmentPreperation();
+
+      ResponseEntity<String> responseEntity = riotLeagueRepository
+              .findGrandmasterSummonersByQueue(queue);
+
+      Assert.assertEquals("Check http request!", HttpStatus.OK, responseEntity.getStatusCode());
+
+      RiotLeagueResult riotLeagueResult = null;
+      try {
+        riotLeagueResult = objectMapper.readValue(responseEntity.getBody(), RiotLeagueResult.class);
+      } catch (JsonProcessingException e) {
+        e.printStackTrace();
+      }
+
+      System.out.println(riotLeagueResult);
+    }
+
+    @ParameterizedTest
+    @EnumSource(LeagueQueue.class)
+    public void findMasterSummonersByQueueTest(LeagueQueue queue){
+      testEnvironmentPreperation();
+
+      ResponseEntity<String> responseEntity = riotLeagueRepository
+              .findMasterSummonersByQueue(queue);
+
+      Assert.assertEquals("Check http request!", HttpStatus.OK, responseEntity.getStatusCode());
+
+      RiotLeagueResult riotLeagueResult = null;
+      try {
+        riotLeagueResult = objectMapper.readValue(responseEntity.getBody(), RiotLeagueResult.class);
+      } catch (JsonProcessingException e) {
+        e.printStackTrace();
+      }
+
+      System.out.println(riotLeagueResult);
 
     }
 
     @Test
     public void findSummonersLeagueEntriesBySummonerIDTest(){
-
+      // This is useless, we won't use this in the future.
     }
 
-    @Test
-    public void findSummonersLeagueEntriesByLeagueIDTest(){
+    private final String[] source = new String[]{};
+
+    @ParameterizedTest
+    @EnumSource(LeagueQueue.class)
+    public void findSummonersLeagueEntriesByLeagueIDTest(LeagueQueue queue){
+      testEnvironmentPreperation();
+      // Find a leagueId
+      // compare the answer with the leagueId and the queue
+      ResponseEntity<String> responseEntity = null;
+      ResponseEntity<String> expectedEntity = null;
+      RiotLeagueResult riotLeagueResult = null;
+      RiotLeagueResult expected = null;
+
+      if(queue == LeagueQueue.RANKED_FLEX_SR)
+        responseEntity = riotLeagueRepository.findSummonersLeagueEntriesByLeagueID(leagueIdFlex);
+      else if(queue == LeagueQueue.RANKED_SOLO_5x5)
+        responseEntity = riotLeagueRepository.findSummonersLeagueEntriesByLeagueID(leagueIdSolo);
+
+      Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+      expectedEntity = riotLeagueRepository.findChallengerRiotSummonersByQueue(queue);
+
+      Assert.assertEquals(HttpStatus.OK, expectedEntity.getStatusCode());
+
+      try {
+        riotLeagueResult = objectMapper.readValue(responseEntity.getBody(), RiotLeagueResult.class);
+        expected = objectMapper.readValue(expectedEntity.getBody(), RiotLeagueResult.class);
+      } catch (JsonProcessingException e) {
+        e.printStackTrace();
+      }
+
+      System.out.println(riotLeagueResult);
+      System.out.println(expected);
+
+      Assert.assertEquals("Same league id queried, they should equal.", expected, riotLeagueResult);
 
     }
 

--- a/src/test/java/com/unbeatable/riotapi/riotclienttests/RiotClientLeagueTests.java
+++ b/src/test/java/com/unbeatable/riotapi/riotclienttests/RiotClientLeagueTests.java
@@ -1,0 +1,43 @@
+package com.unbeatable.riotapi.riotclienttests;
+
+import com.unbeatable.riotapi.client.LeagueQueue;
+import org.junit.Test;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class RiotClientLeagueTests {
+
+    @Test
+    @EnumSource(LeagueQueue.class)
+    public void findChallengerRiotSummonersByQueueTest(){
+
+    }
+
+    @Test
+    @EnumSource(LeagueQueue.class)
+    public void findGrandmasterSummonersByQueueTest(){
+
+    }
+
+    @Test
+    @EnumSource(LeagueQueue.class)
+    public void findMasterSummonersByQueueTest(){
+
+    }
+
+    @Test
+    public void findSummonersLeagueEntriesBySummonerIDTest(){
+
+    }
+
+    @Test
+    public void findSummonersLeagueEntriesByLeagueIDTest(){
+
+    }
+
+    @Test
+    // @EnumSource({LeagueQueue.class, LeagueTier.class, LeagueDivison.class})
+    public void findAllLeagueEntriesByQueueAndByTierAndByDivisonTest(){
+
+    }
+
+}


### PR DESCRIPTION
I finished league repository implementation of riot client and also I created the API counter system to check if we reach the riot API limit, but I didn't store them in database.
<h2>Written Components</h2>
<ul>
<li>Redis Tests</li>
<li>Summoner Controller Tests</li>
<li>Riot Client League Repository</li>
<li>Riot Client API Counter</li>
<li>Riot Client League Repository Tests</li>
</ul>

<h2 ">Found Issues</h2>
While I write unit tests for riot client league repository. I realized that if the client sends multiple requests from single repository to different endpoints the URL code concatanates the old one with the new one.
<h2>Solved</h2>

So I easily wrote a clearURL method and I run the method for all client repositories.
